### PR TITLE
refactor: Consolidate JSON parser tests into Configuration/Json direc…

### DIFF
--- a/src/Tanuki.Tests/Configuration/Json/JsonConfigParserTests.cs
+++ b/src/Tanuki.Tests/Configuration/Json/JsonConfigParserTests.cs
@@ -5,7 +5,7 @@ using Onyx.Tanuki.Configuration.Exceptions;
 using Onyx.Tanuki.Configuration.Json;
 using Xunit;
 
-namespace Onyx.Tanuki.Tests.Json;
+namespace Onyx.Tanuki.Tests.Configuration.Json;
 
 public class JsonConfigParserTests
 {

--- a/src/Tanuki.Tests/Configuration/Json/JsonResponseParserTests.cs
+++ b/src/Tanuki.Tests/Configuration/Json/JsonResponseParserTests.cs
@@ -6,7 +6,7 @@ using Onyx.Tanuki.Configuration.Exceptions;
 using Onyx.Tanuki.Configuration.Json;
 using Xunit;
 
-namespace Onyx.Tanuki.Tests.Configuration;
+namespace Onyx.Tanuki.Tests.Configuration.Json;
 
 public class JsonResponseParserTests
 {


### PR DESCRIPTION
## Summary

- Move JSON parser test files to `Tests/Configuration/Json/` directory to match the source code organization at `Tanuki.Runtime/Configuration/Json/`
- Update test namespaces to `Onyx.Tanuki.Tests.Configuration.Json`
- JSON parser source files (JsonExampleParser, JsonContentParser, JsonResponseParser, JsonOperationParser, JsonPathsParser, JsonConfigParser) are already correctly located in `src/Tanuki.Runtime/Configuration/Json/`

## Changes

- `JsonConfigParserTests.cs`: moved from `Tests/Json/` to `Tests/Configuration/Json/`
- `JsonResponseParserTests.cs`: moved from `Tests/Configuration/` to `Tests/Configuration/Json/`

## Test plan

- [x] All JSON parser tests pass (15/15)
- [x] Build succeeds
- [x] Namespace references updated correctly