### PR TITLE
[Step 8] refactor: Update project references to use Tanuki.Runtime

### DIFF
--- a/src/Tanuki.Cli/Tanuki.Cli.csproj
+++ b/src/Tanuki.Cli/Tanuki.Cli.csproj
@@ -2,12 +2,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Tanuki.Runtime\Tanuki.Runtime.csproj" />
-    <ProjectReference Include="..\Tanuki\Onyx.Tanuki.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.3.0" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />


### PR DESCRIPTION
## Overview

This PR implements Step 8 of the refactoring plan: Update project references to use Tanuki.Runtime.

## Changes

- **Removed Tanuki project reference from Tanuki.Cli**: The Tanuki.Cli project no longer references the Tanuki project, as all functionality now comes from Tanuki.Runtime
- **Updated ASP.NET Core dependencies**: Replaced old package references (Microsoft.AspNetCore.Hosting and Microsoft.AspNetCore.Server.Kestrel) with Microsoft.AspNetCore.App framework reference for better compatibility with .NET 9.0

## Verification

- âœ… All projects build successfully
- âœ… All 82 tests pass
- âœ… No linting errors
- âœ… Tanuki project already references Tanuki.Runtime (verified, no changes needed)
- âœ… Program.cs already uses Runtime classes (verified, no changes needed)
- âœ… All using statements in Tanuki.Cli and test files are correct (verified, no changes needed)

## Impact

- Tanuki.Cli now only depends on Tanuki.Runtime, removing the dependency on the Tanuki project
- All functionality continues to work as expected
- No breaking changes

## Related

Part of the refactoring plan: Step 8 - Update project references